### PR TITLE
Edit Slack API url

### DIFF
--- a/service.yml
+++ b/service.yml
@@ -40,7 +40,7 @@ config:
             line: https://api.line.me
             telegram: https://api.telegram.org
             fbmessenger: https://graph.facebook.com/v2.6/me/messages
-            slack: https://api.slack.com
+            slack: https://slack.com/api
             qiscus: https://<appId>.qiscus.com
 
 commands:


### PR DESCRIPTION
I changed default Slack API url, so another user can use it.