### PR TITLE
Fix proper handling for kata versions

### DIFF
--- a/lib/components/bots/bot.js
+++ b/lib/components/bots/bot.js
@@ -85,11 +85,11 @@ class Bot extends merapi_1.Component {
     }
     versions(options) {
         return __awaiter(this, void 0, void 0, function* () {
-            const botId = this.helper.getBotId();
-            if (!botId) {
-                throw new Error("BOT ID HAS NOT DEFINED");
-            }
             try {
+                const botId = this.helper.getBotId();
+                if (!botId) {
+                    throw new Error("BOT ID HAS NOT DEFINED");
+                }
                 const { data, response } = yield this.helper.toPromise(this.api.botApi, this.api.botApi.botsBotIdVersionsGet, botId);
                 if (data) {
                     console.log("Bot Versions : ");
@@ -108,7 +108,12 @@ class Bot extends merapi_1.Component {
                 }
             }
             catch (e) {
-                console.log(this.helper.wrapError(e));
+                if (e.code === "ENOENT") {
+                    console.log("kata versions must be executed in bot directory with bot.yml");
+                }
+                else {
+                    console.log(this.helper.wrapError(e));
+                }
             }
         });
     }

--- a/test/bots/bot.spec.ts
+++ b/test/bots/bot.spec.ts
@@ -14,12 +14,12 @@ import Tester from "../../components/scripts/tester";
 import Zaun from "../../components/api/zaun";
 
 @suite class BotTest {
-    private config : IConfig;
-    private helper : IHelper;
-    private compile : ICompile;
-    private tester : ITester;
-    private api : any;
-    private bot : any;
+    private config: IConfig;
+    private helper: IHelper;
+    private compile: ICompile;
+    private tester: ITester;
+    private api: any;
+    private bot: any;
     private botDesc = {
         schema: "kata.ai/schema/kata-ml/1.0",
         name: "Bot Name",
@@ -116,6 +116,7 @@ import Zaun from "../../components/api/zaun";
 
     @test public async "should throw error when botId is not defined"() {
         const getBotIdStub = stub(this.helper, "getBotId").returns(null);
+        const consoleLogStub = stub(console, "log");
         let error;
 
         try {
@@ -125,7 +126,8 @@ import Zaun from "../../components/api/zaun";
         }
 
         getBotIdStub.restore();
-        deepEqual(error.message, "BOT ID HAS NOT DEFINED");
+        consoleLogStub.restore();
+        assert.calledWith(consoleLogStub, "BOT ID HAS NOT DEFINED");
     }
 
     @test public async "should call bot versions successfully"() {


### PR DESCRIPTION
I change the error message for kata versions if `bot.yml` doesn't exist