### PR TITLE
Change endpoint kata push to projectsProjectIdBotRevisionsRevisionPut

### DIFF
--- a/components/bots/bot.ts
+++ b/components/bots/bot.ts
@@ -190,7 +190,6 @@ export default class Bot extends Component {
 
         let latestBotRevision;
         try {
-            // 
             const { response: { body: data } } = await this.helper.toPromise(
                 this.api.projectApi,
                 this.api.projectApi.projectsProjectIdBotGet, botDesc.id

--- a/lib/components/bots/bot.js
+++ b/lib/components/bots/bot.js
@@ -194,9 +194,24 @@ class Bot extends merapi_1.Component {
             }
             const projectId = this.getProject();
             botDesc.id = projectId;
-            const { data: newBot } = yield this.helper.toPromise(this.api.botApi, this.api.botApi.projectsProjectIdBotRevisionsPost, projectId, botDesc);
-            const { data: project } = yield this.helper.toPromise(this.api.projectApi, this.api.projectApi.projectsProjectIdGet, projectId);
-            console.log(`Updated bot ${colors.green(project.name)} with revision: ${newBot.revision.substring(0, 7)}`);
+            let latestBotRevision;
+            try {
+                // 
+                const { response: { body: data } } = yield this.helper.toPromise(this.api.projectApi, this.api.projectApi.projectsProjectIdBotGet, botDesc.id);
+                if (data.revision) {
+                    latestBotRevision = data.revision;
+                    const { data: newBot } = yield this.helper.toPromise(this.api.botApi, this.api.botApi.projectsProjectIdBotRevisionsRevisionPut, projectId, latestBotRevision, botDesc);
+                    const { data: project } = yield this.helper.toPromise(this.api.projectApi, this.api.projectApi.projectsProjectIdGet, projectId);
+                    console.log(`Updated bot ${colors.green(project.name)} with revision: ${newBot.revision.substring(0, 7)}`);
+                }
+                else {
+                    throw Error("Could not find latest bot revision from this project.");
+                }
+            }
+            catch (e) {
+                console.error("Error");
+                console.log(this.helper.wrapError(e));
+            }
             this.helper.dumpYaml("./bot.yml", desc);
         });
     }

--- a/lib/components/bots/bot.js
+++ b/lib/components/bots/bot.js
@@ -196,7 +196,6 @@ class Bot extends merapi_1.Component {
             botDesc.id = projectId;
             let latestBotRevision;
             try {
-                // 
                 const { response: { body: data } } = yield this.helper.toPromise(this.api.projectApi, this.api.projectApi.projectsProjectIdBotGet, botDesc.id);
                 if (data.revision) {
                     latestBotRevision = data.revision;


### PR DESCRIPTION
Code Changes on Kata-CLI

Pada file kata-cli/components/bots/bot.ts method push, ubah bagian ini:

```
const projectId = this.getProject();
botDesc.id = projectId;
const { data: newBot } = await this.helper.toPromise(
    this.api.botApi, this.api.botApi.projectsProjectIdBotRevisionsPost, 
    projectId, botDesc
);
```

menjadi: 

```
let latestBotRevision;
try {
    const { response: { body: data } } = await this.helper.toPromise(
        this.api.projectApi,
        this.api.projectApi.projectsProjectIdBotGet, botDesc.id
    );

    if (data.revision) {
        latestBotRevision = data.revision;

        const { data: newBot } = await this.helper.toPromise(
            this.api.botApi, this.api.botApi.projectsProjectIdBotRevisionsRevisionPut, 
            projectId, latestBotRevision, botDesc
        );
        const { data: project } = await this.helper.toPromise(
            this.api.projectApi,
            this.api.projectApi.projectsProjectIdGet, projectId
        );

        console.log(`Updated bot ${colors.green(project.name)} with revision: ${newBot.revision.substring(0, 7)}`);

    } else {
        throw Error("Could not find latest bot revision from this project.");
    }
} catch (e) {
    console.error("Error");
    console.log(this.helper.wrapError(e));
}
```
endpoint `projectsProjectIdBotRevisionsRevisionPut` membutuhkan param latest bot revision, sehingga pemanggilan endpoint dilakukan jika ada value dari param latest bot revision.


