### PR TITLE
Add validation on environment url and project name

### DIFF
--- a/components/bots/environment.ts
+++ b/components/bots/environment.ts
@@ -12,6 +12,11 @@ export default class Environment {
     public async create(slug: string) {
         const projectId = this.helper.getProjectId();
 
+        if (slug.length > 20) {
+            console.error("error: Namespace length can not exceed 20 characters");
+            return;
+        }
+
         try {
             const deployment = await this.getLatestDeployment();
             if (!deployment) {

--- a/components/projects/project.ts
+++ b/components/projects/project.ts
@@ -13,13 +13,25 @@ export default class Project {
     ) { }
 
     public async create() {
-        const projectData = await this.helper.inquirerPrompt([
+        let projectData: Record<string, any> = {name : ""};
+        while (true) {
+          projectData = await this.helper.inquirerPrompt([
             {
-                type: "text",
-                name: "name",
-                message: "Project name:",
+              type: "text",
+              name: "name",
+              message: "Project name:",
             },
-        ]);
+          ]);
+          if (projectData.name.length > 20) {
+              console.error("error: Project name length can not exceed 20 characters");
+          }
+          else if (!/^[A-Za-z][A-Za-z0-9_-]*[A-Za-z0-9]$/.test(projectData.name)) {
+              console.error("error: Project name must start with alphabet characters and contains only aplhanumeric character, dash, or underscore");
+          }
+          else {
+              break;
+          }
+        }
         const inquiredOptions = await this.helper.inquirerPrompt([
             {
                 type: "number",

--- a/lib/components/bots/environment.js
+++ b/lib/components/bots/environment.js
@@ -18,6 +18,10 @@ class Environment {
     create(slug) {
         return __awaiter(this, void 0, void 0, function* () {
             const projectId = this.helper.getProjectId();
+            if (slug.length > 20) {
+                console.error("error: Slug length can not exceed 20 characters");
+                return;
+            }
             try {
                 const deployment = yield this.getLatestDeployment();
                 if (!deployment) {

--- a/lib/components/projects/project.js
+++ b/lib/components/projects/project.js
@@ -18,13 +18,25 @@ class Project {
     }
     create() {
         return __awaiter(this, void 0, void 0, function* () {
-            const projectData = yield this.helper.inquirerPrompt([
-                {
-                    type: "text",
-                    name: "name",
-                    message: "Project name:",
-                },
-            ]);
+            let projectData = { name: "" };
+            while (true) {
+                projectData = yield this.helper.inquirerPrompt([
+                    {
+                        type: "text",
+                        name: "name",
+                        message: "Project name:",
+                    },
+                ]);
+                if (projectData.name.length > 20) {
+                    console.error("error: Project name length can not exceed 20 characters");
+                }
+                else if (!/^[A-Za-z][A-Za-z0-9_-]*[A-Za-z0-9]$/.test(projectData.name)) {
+                    console.error("error: Project name must start with alphabet characters and contains only aplhanumeric character or underscore");
+                }
+                else {
+                    break;
+                }
+            }
             const inquiredOptions = yield this.helper.inquirerPrompt([
                 {
                     type: "number",


### PR DESCRIPTION
Ref: PLATFORM-1950

In Kata Platform, environment url and project name are limited to 20 characters due to display issues on the card.

This PR add validation to ensure that the environment url and project name is limited to 20 characters.