### PR TITLE
Change get nlu revision endpoint

### DIFF
--- a/components/bots/deployment.ts
+++ b/components/bots/deployment.ts
@@ -34,11 +34,12 @@ export default class Deployment {
         }
 
         try {
-            const { response: {body: data} } = await this.helper.toPromise(this.api.projectApi, 
-                this.api.projectApi.projectsProjectIdNluGet, projectId);                
-            if (data.snapshot) {
-                nluRevision = data.snapshot;
-            }
+            const { response: {body: data} } = await this.helper.toPromise(this.api.projectApi,
+                this.api.projectApi.projectsProjectIdNluRevisionsGet, projectId);
+
+          if (data.data[0] && data.data[0].revision) {
+              nluRevision = data.data[0].revision;
+          }
         } catch (e) {
             console.error("Error");
             console.log(this.helper.wrapError(e));

--- a/lib/components/bots/deployment.js
+++ b/lib/components/bots/deployment.js
@@ -33,9 +33,9 @@ class Deployment {
                 console.log(this.helper.wrapError(e));
             }
             try {
-                const { response: { body: data } } = yield this.helper.toPromise(this.api.projectApi, this.api.projectApi.projectsProjectIdNluGet, projectId);
-                if (data.snapshot) {
-                    nluRevision = data.snapshot;
+                const { response: { body: data } } = yield this.helper.toPromise(this.api.projectApi, this.api.projectApi.projectsProjectIdNluRevisionsGet, projectId);
+                if (data.data[0] && data.data[0].revision) {
+                    nluRevision = data.data[0].revision;
                 }
             }
             catch (e) {


### PR DESCRIPTION
Current nlu endpoint is not the same endpoint used by tafel, we change the get nlu revision endpoint to the one that also used by tafel.