### PR TITLE
Add impersonate and unimpersonate features

### DIFF
--- a/components/scripts/helper.ts
+++ b/components/scripts/helper.ts
@@ -110,6 +110,25 @@ export default class Helper extends Component {
         return false;
     }
 
+    public deleteKeyToken(userName: string) {
+        const jsonPath = `${os.homedir()}/.katajson`;
+        let jsonProp;
+
+        if (fs.existsSync(jsonPath)) {
+            jsonProp = JSON.parse(fs.readFileSync(jsonPath, "utf8"));
+            // if userName token exist 
+            if (userName in jsonProp) {
+                delete jsonProp.token[userName];
+            } else {
+                return new Error(`Failed to unimpersonate ${(userName)}`);
+            }
+        } else {
+            jsonProp = {};
+        }
+
+        return jsonProp;
+    }
+
     public toPromise(ctx : any, func : any, ...args : any[]) : Promise<any> {
         return new Promise((resolve, reject) => {
             args.push((error : Error, data : any, response : Response) => {

--- a/components/scripts/helper.ts
+++ b/components/scripts/helper.ts
@@ -117,15 +117,18 @@ export default class Helper extends Component {
         if (fs.existsSync(jsonPath)) {
             jsonProp = JSON.parse(fs.readFileSync(jsonPath, "utf8"));
             // if userName token exist 
-            if (userName in jsonProp) {
+            if (userName in jsonProp.token) {
+                jsonProp.current_login = "admin";
                 delete jsonProp.token[userName];
+                delete jsonProp.projectId;
+                delete jsonProp.projectName;
             } else {
                 return new Error(`Failed to unimpersonate ${(userName)}`);
             }
         } else {
             jsonProp = {};
         }
-
+        fs.writeFileSync(jsonPath, JSON.stringify(jsonProp), "utf8");
         return jsonProp;
     }
 

--- a/components/users/user.ts
+++ b/components/users/user.ts
@@ -269,8 +269,8 @@ export default class User extends Component {
             if (currentLogin === userName) {
                 throw new Error(`Unable to impersonate : already on ${currentLogin}`);
             } else {
-                const currToken = this.helper.getCurrentToken().token;
-                this.api.authApi.apiClient.defaultHeaders.Authorization = `Bearer ${currToken}`;
+                const currentToken = this.helper.getCurrentToken().token;
+                this.api.authApi.apiClient.defaultHeaders.Authorization = `Bearer ${currentToken}`;
 
                 // get user id from username
                 const limit: number = 1;
@@ -308,6 +308,17 @@ export default class User extends Component {
 
         }
     }
+
+    // unimpersonate command
+    public async unimpersonate(userName?: string) {
+        try {
+            const currentLogin = this.helper.getProp("current_login");
+            console.log(`Succesfully unimpersonate user. Now your current login is ${colors.green(currentLogin)}`);
+        } catch (error) {
+            console.log(this.helper.wrapError(error));
+        }
+    }
+
 
     private setToken(userInfo: JsonObject, token: string) {
         this.helper.setProp("current_login", userInfo.name);

--- a/components/users/user.ts
+++ b/components/users/user.ts
@@ -257,6 +257,7 @@ export default class User extends Component {
     public async impersonate(userName: string) {
         // TODO : dibuat seperti login, pake inquirer.
         try {
+            userName = userName.toLowerCase();
             if (!userName) {
                 throw new Error(`username is required`);
             }
@@ -285,7 +286,6 @@ export default class User extends Component {
                     throw new Error(`Sorry, username is not exist.`);
                 }
                 
-                console.log(name, id);
                 // impersonate function
                 const result = await this.helper.toPromise(
                     this.api.authApi, this.api.authApi.impersonatePost, 
@@ -312,7 +312,15 @@ export default class User extends Component {
     // unimpersonate command
     public async unimpersonate(userName?: string) {
         try {
-            const currentLogin = this.helper.getProp("current_login");
+            const name = userName.toLowerCase();
+            let currentLogin = this.helper.getProp("current_login");
+            if (name !== currentLogin) {
+                throw new Error(`Failed to unimpersonate. Please check your current username.`);
+            }
+            // helper to remove userName key from katajson
+            this.helper.deleteKeyToken(name);
+            // get updated currentLogin
+            currentLogin = this.helper.getProp("current_login");
             console.log(`Succesfully unimpersonate user. Now your current login is ${colors.green(currentLogin)}`);
         } catch (error) {
             console.log(this.helper.wrapError(error));

--- a/components/users/user.ts
+++ b/components/users/user.ts
@@ -257,7 +257,6 @@ export default class User extends Component {
     public async impersonate(userName: string) {
         // TODO : dibuat seperti login, pake inquirer.
         try {
-            userName = userName.toLowerCase();
             if (!userName) {
                 throw new Error(`username is required`);
             }
@@ -312,13 +311,12 @@ export default class User extends Component {
     // unimpersonate command
     public async unimpersonate(userName?: string) {
         try {
-            const name = userName.toLowerCase();
             let currentLogin = this.helper.getProp("current_login");
-            if (name !== currentLogin) {
+            if (userName !== currentLogin) {
                 throw new Error(`Failed to unimpersonate. Please check your current username.`);
             }
             // helper to remove userName key from katajson
-            this.helper.deleteKeyToken(name);
+            this.helper.deleteKeyToken(userName);
             // get updated currentLogin
             currentLogin = this.helper.getProp("current_login");
             console.log(`Succesfully unimpersonate user. Now your current login is ${colors.green(currentLogin)}`);

--- a/components/users/user.ts
+++ b/components/users/user.ts
@@ -280,19 +280,26 @@ export default class User extends Component {
                 const data = response.body;
                 const name = data.map( (datum: any) => datum.username )[0];
                 const id = data.map( (datum: any) => datum.userId )[0];
-
+                
                 if ( userName !== name ) {
                     throw new Error(`Sorry, username is not exist.`);
                 }
-
+                
+                console.log(name, id);
                 // impersonate function
-                await this.helper.toPromise(
+                const result = await this.helper.toPromise(
                     this.api.authApi, this.api.authApi.impersonatePost, 
                     {
                         userId: id,
                         namespace: "platform"
                     }
                 );
+
+                const impersonateToken = result.data.id;
+                const type = result.data.type;
+                this.setToken({ name, type }, impersonateToken);
+
+                // use impersonate token
                 console.log(`Succesfully impersonate as ${colors.green(name)}`);
             }
 

--- a/interfaces/main.ts
+++ b/interfaces/main.ts
@@ -298,6 +298,7 @@ export interface IHelper {
     loadYamlOrJsonFile(filePath: string) : JsonObject;
     inquirerPrompt(questions: JsonObject[]): Promise<JsonObject>;
     delete() : Boolean;
+    deleteKeyToken(username: string): JsonObject;
     wrapError(error : any) : string;
     difference(object: any, base: any): Object;
     checkNotificationStatus() : Boolean;

--- a/lib/components/scripts/helper.js
+++ b/lib/components/scripts/helper.js
@@ -105,6 +105,28 @@ class Helper extends merapi_1.Component {
         }
         return false;
     }
+    deleteKeyToken(userName) {
+        const jsonPath = `${os.homedir()}/.katajson`;
+        let jsonProp;
+        if (fs.existsSync(jsonPath)) {
+            jsonProp = JSON.parse(fs.readFileSync(jsonPath, "utf8"));
+            // if userName token exist 
+            if (userName in jsonProp.token) {
+                jsonProp.current_login = "admin";
+                delete jsonProp.token[userName];
+                delete jsonProp.projectId;
+                delete jsonProp.projectName;
+            }
+            else {
+                return new Error(`Failed to unimpersonate ${(userName)}`);
+            }
+        }
+        else {
+            jsonProp = {};
+        }
+        fs.writeFileSync(jsonPath, JSON.stringify(jsonProp), "utf8");
+        return jsonProp;
+    }
     toPromise(ctx, func, ...args) {
         return new Promise((resolve, reject) => {
             args.push((error, data, response) => {

--- a/lib/components/users/user.js
+++ b/lib/components/users/user.js
@@ -269,8 +269,8 @@ class User extends merapi_1.Component {
                     throw new Error(`Unable to impersonate : already on ${currentLogin}`);
                 }
                 else {
-                    const currToken = this.helper.getCurrentToken().token;
-                    this.api.authApi.apiClient.defaultHeaders.Authorization = `Bearer ${currToken}`;
+                    const currentToken = this.helper.getCurrentToken().token;
+                    this.api.authApi.apiClient.defaultHeaders.Authorization = `Bearer ${currentToken}`;
                     // get user id from username
                     const limit = 1;
                     const { response } = yield this.helper.toPromise(this.api.userApi, this.api.userApi.usersSearchGet, userName, limit);
@@ -286,13 +286,24 @@ class User extends merapi_1.Component {
                         userId: id,
                         namespace: "platform"
                     });
-                    console.log(result.data);
                     const impersonateToken = result.data.id;
                     const type = result.data.type;
                     this.setToken({ name, type }, impersonateToken);
                     // use impersonate token
                     console.log(`Succesfully impersonate as ${colors.green(name)}`);
                 }
+            }
+            catch (error) {
+                console.log(this.helper.wrapError(error));
+            }
+        });
+    }
+    // unimpersonate command
+    unimpersonate(userName) {
+        return __awaiter(this, void 0, void 0, function* () {
+            try {
+                const currentLogin = this.helper.getProp("current_login");
+                console.log(`Succesfully unimpersonate user. Now your current login is ${colors.green(currentLogin)}`);
             }
             catch (error) {
                 console.log(this.helper.wrapError(error));

--- a/lib/components/users/user.js
+++ b/lib/components/users/user.js
@@ -10,6 +10,7 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", { value: true });
 const merapi_1 = require("merapi");
 const inquirer = require("inquirer");
+const colors = require("colors");
 class User extends merapi_1.Component {
     constructor(helper, api) {
         super();
@@ -247,6 +248,45 @@ class User extends merapi_1.Component {
                 }
                 const newUser = yield this.helper.toPromise(this.api.userApi, this.api.userApi.usersPost, { username, password: password.answer, roleId: role });
                 console.log(`New user ${newUser.data.username} created !`);
+            }
+            catch (error) {
+                console.log(this.helper.wrapError(error));
+            }
+        });
+    }
+    impersonate(userName) {
+        return __awaiter(this, void 0, void 0, function* () {
+            // TODO : dibuat seperti login, pake inquirer.
+            try {
+                if (!userName) {
+                    throw new Error(`username is required`);
+                }
+                const currentLogin = this.helper.getProp("current_login");
+                if (currentLogin !== "admin") {
+                    throw new Error(`Your login status is not superadmin. You are not authorized to impersonate a user`);
+                }
+                if (currentLogin === userName) {
+                    throw new Error(`Unable to impersonate : already on ${currentLogin}`);
+                }
+                else {
+                    const currToken = this.helper.getCurrentToken().token;
+                    this.api.authApi.apiClient.defaultHeaders.Authorization = `Bearer ${currToken}`;
+                    // get user id from username
+                    const limit = 1;
+                    const { response } = yield this.helper.toPromise(this.api.userApi, this.api.userApi.usersSearchGet, userName, limit);
+                    const data = response.body;
+                    const name = data.map((datum) => datum.username)[0];
+                    const id = data.map((datum) => datum.userId)[0];
+                    if (userName !== name) {
+                        throw new Error(`Sorry, username is not exist.`);
+                    }
+                    // impersonate function
+                    yield this.helper.toPromise(this.api.authApi, this.api.authApi.impersonatePost, {
+                        userId: id,
+                        namespace: "platform"
+                    });
+                    console.log(`Succesfully impersonate as ${colors.green(name)}`);
+                }
             }
             catch (error) {
                 console.log(this.helper.wrapError(error));

--- a/lib/components/users/user.js
+++ b/lib/components/users/user.js
@@ -258,39 +258,32 @@ class User extends merapi_1.Component {
         return __awaiter(this, void 0, void 0, function* () {
             // TODO : dibuat seperti login, pake inquirer.
             try {
-                if (!userName) {
-                    throw new Error(`username is required`);
-                }
-                const currentLogin = this.helper.getProp("current_login");
+                const currentLogin = this.helper.getProp("current_login").toString();
                 if (currentLogin !== "admin") {
                     throw new Error(`Your login status is not superadmin. You are not authorized to impersonate a user`);
                 }
-                if (currentLogin === userName) {
-                    throw new Error(`Unable to impersonate : already on ${currentLogin}`);
+                // set header bearer token
+                const currentToken = this.helper.getCurrentToken().token.toString();
+                this.api.authApi.apiClient.defaultHeaders.Authorization = `Bearer ${currentToken}`;
+                // get user id from username
+                const limit = 1;
+                const { response } = yield this.helper.toPromise(this.api.userApi, this.api.userApi.usersSearchGet, userName, limit);
+                const users = response.body;
+                const name = users.map((user) => user.username)[0].toString();
+                const id = users.map((user) => user.userId)[0].toString();
+                if (userName !== name) {
+                    throw new Error(`Sorry, username is not exist.`);
                 }
-                else {
-                    const currentToken = this.helper.getCurrentToken().token;
-                    this.api.authApi.apiClient.defaultHeaders.Authorization = `Bearer ${currentToken}`;
-                    // get user id from username
-                    const limit = 1;
-                    const { response } = yield this.helper.toPromise(this.api.userApi, this.api.userApi.usersSearchGet, userName, limit);
-                    const data = response.body;
-                    const name = data.map((datum) => datum.username)[0];
-                    const id = data.map((datum) => datum.userId)[0];
-                    if (userName !== name) {
-                        throw new Error(`Sorry, username is not exist.`);
-                    }
-                    // impersonate function
-                    const result = yield this.helper.toPromise(this.api.authApi, this.api.authApi.impersonatePost, {
-                        userId: id,
-                        namespace: "platform"
-                    });
-                    const impersonateToken = result.data.id;
-                    const type = result.data.type;
-                    this.setToken({ name, type }, impersonateToken);
-                    // use impersonate token
-                    console.log(`Succesfully impersonate as ${colors.green(name)}`);
-                }
+                // impersonate function
+                const result = yield this.helper.toPromise(this.api.authApi, this.api.authApi.impersonatePost, {
+                    userId: id,
+                    namespace: "platform"
+                });
+                // set value on .katajson
+                const impersonateToken = result.data.id.toString();
+                const type = result.data.type.toString();
+                this.setToken({ name, type }, impersonateToken);
+                console.log(`Succesfully impersonate as ${colors.green(name)}`);
             }
             catch (error) {
                 console.log(this.helper.wrapError(error));
@@ -298,17 +291,12 @@ class User extends merapi_1.Component {
         });
     }
     // unimpersonate command
-    unimpersonate(userName) {
+    unimpersonate() {
         return __awaiter(this, void 0, void 0, function* () {
             try {
-                let currentLogin = this.helper.getProp("current_login");
-                if (userName !== currentLogin) {
-                    throw new Error(`Failed to unimpersonate. Please check your current username.`);
-                }
-                // helper to remove userName key from katajson
+                const userName = this.helper.getProp("current_login").toString();
                 this.helper.deleteKeyToken(userName);
-                // get updated currentLogin
-                currentLogin = this.helper.getProp("current_login");
+                const currentLogin = this.helper.getProp("current_login").toString();
                 console.log(`Succesfully unimpersonate user. Now your current login is ${colors.green(currentLogin)}`);
             }
             catch (error) {

--- a/lib/components/users/user.js
+++ b/lib/components/users/user.js
@@ -258,6 +258,7 @@ class User extends merapi_1.Component {
         return __awaiter(this, void 0, void 0, function* () {
             // TODO : dibuat seperti login, pake inquirer.
             try {
+                userName = userName.toLowerCase();
                 if (!userName) {
                     throw new Error(`username is required`);
                 }
@@ -280,7 +281,6 @@ class User extends merapi_1.Component {
                     if (userName !== name) {
                         throw new Error(`Sorry, username is not exist.`);
                     }
-                    console.log(name, id);
                     // impersonate function
                     const result = yield this.helper.toPromise(this.api.authApi, this.api.authApi.impersonatePost, {
                         userId: id,
@@ -302,7 +302,15 @@ class User extends merapi_1.Component {
     unimpersonate(userName) {
         return __awaiter(this, void 0, void 0, function* () {
             try {
-                const currentLogin = this.helper.getProp("current_login");
+                const name = userName.toLowerCase();
+                let currentLogin = this.helper.getProp("current_login");
+                if (name !== currentLogin) {
+                    throw new Error(`Failed to unimpersonate. Please check your current username.`);
+                }
+                // helper to remove userName key from katajson
+                this.helper.deleteKeyToken(name);
+                // get updated currentLogin
+                currentLogin = this.helper.getProp("current_login");
                 console.log(`Succesfully unimpersonate user. Now your current login is ${colors.green(currentLogin)}`);
             }
             catch (error) {

--- a/lib/components/users/user.js
+++ b/lib/components/users/user.js
@@ -280,11 +280,17 @@ class User extends merapi_1.Component {
                     if (userName !== name) {
                         throw new Error(`Sorry, username is not exist.`);
                     }
+                    console.log(name, id);
                     // impersonate function
-                    yield this.helper.toPromise(this.api.authApi, this.api.authApi.impersonatePost, {
+                    const result = yield this.helper.toPromise(this.api.authApi, this.api.authApi.impersonatePost, {
                         userId: id,
                         namespace: "platform"
                     });
+                    console.log(result.data);
+                    const impersonateToken = result.data.id;
+                    const type = result.data.type;
+                    this.setToken({ name, type }, impersonateToken);
+                    // use impersonate token
                     console.log(`Succesfully impersonate as ${colors.green(name)}`);
                 }
             }

--- a/lib/components/users/user.js
+++ b/lib/components/users/user.js
@@ -258,7 +258,6 @@ class User extends merapi_1.Component {
         return __awaiter(this, void 0, void 0, function* () {
             // TODO : dibuat seperti login, pake inquirer.
             try {
-                userName = userName.toLowerCase();
                 if (!userName) {
                     throw new Error(`username is required`);
                 }
@@ -302,13 +301,12 @@ class User extends merapi_1.Component {
     unimpersonate(userName) {
         return __awaiter(this, void 0, void 0, function* () {
             try {
-                const name = userName.toLowerCase();
                 let currentLogin = this.helper.getProp("current_login");
-                if (name !== currentLogin) {
+                if (userName !== currentLogin) {
                     throw new Error(`Failed to unimpersonate. Please check your current username.`);
                 }
                 // helper to remove userName key from katajson
-                this.helper.deleteKeyToken(name);
+                this.helper.deleteKeyToken(userName);
                 // get updated currentLogin
                 currentLogin = this.helper.getProp("current_login");
                 console.log(`Succesfully unimpersonate user. Now your current login is ${colors.green(currentLogin)}`);

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
     "merapi-proxy": "^0.1.7",
     "universal-analytics": "^0.4.20",
     "uuid": "^3.2.1",
-    "zaun": "^2.0.4"
+    "zaun": "^2.0.5"
   },
   "devDependencies": {
     "@types/inquirer": "0.0.43",

--- a/service.yml
+++ b/service.yml
@@ -318,6 +318,10 @@ commands:
                 desc: impersonate as certain user
                 handler: user.impersonate
                 alias: impersonate
+            unimpersonate:
+                desc: unimpersonate current user, set back to admin
+                handler: user.unimpersonate
+                alias: unimpersonate
     nlu:
         type: group
         desc: command for nlu management

--- a/service.yml
+++ b/service.yml
@@ -316,6 +316,7 @@ commands:
                 alias: remove-member
             impersonate:
                 desc: impersonate as certain user
+                args: <username>
                 handler: user.impersonate
                 alias: impersonate
             unimpersonate:

--- a/service.yml
+++ b/service.yml
@@ -314,6 +314,10 @@ commands:
                 args: <username>
                 handler: team.removeMember
                 alias: remove-member
+            impersonate:
+                desc: impersonate as certain user
+                handler: user.impersonate
+                alias: impersonate
     nlu:
         type: group
         desc: command for nlu management


### PR DESCRIPTION
### Overview
Untuk memberikan fitur impersonate untuk super admin, supaya bisa login sebagai user tertentu untuk membantu jika user tersebut menemukan bug yang harus direproduce menggunakan akun user tersebut.

### How to solve the problem
* Super Admin bisa menggunakan perintah `kata login` untuk login sebagai super user.
* Jika terdeteksi user tersebut adalah super admin, maka akan ada perintah `kata impersonate` yang bisa dipanggil.
* Perintah `kata impersonate <userName>` ini menerima satu parameter, yaitu userName.
    * Untuk mengurangi kemungkinan celah keamanan, userName harus lengkap terisi dan tidak bisa dilakukan search.
* Setelah memanggil perintah di atas, maka token login yang sekarang adalah token login sebagai user yang dipilih.
* Untuk kembali menjadi status user Super Admin, bisa menggunakan command `kata unimpersonate <userName>` 

### Additional Info
Perlu untuk merge beberapa PR : 
1. PR Zaun : https://bitbucket.org/yesboss/zaun/pull-requests/372?w=1
2. PR Wache : https://bitbucket.org/yesboss/wache/pull-requests/71/platform-2008-implement-impersonate
3. PR Zaun-Swagger : https://bitbucket.org/yesboss/zaun-swagger/pull-requests/18/add-impersonate-login-and-add-schema
4. Perlu release zaun-swagger version terbaru di npm

### How can the reviewers test the changes
Jika semua PR sudah di merge dan up ke develop.
0. `kata set zaunUrl <zaunUrl>`
1. `kata login` masukkan username dan password untuk superadmin
2. `kata config-view` untuk melihat configurasi akun detail setelah login
3. `kata impersonate <username>`
4. `kata config-view` jika sudah berhasil impersonate, maka akan muncul token untuk username yang di-impersonate
5. `kata list-project` untuk mengecek apakah sudah berhasil menampilkan project dari username yang di-impersonate
6. `kata unimpersonate <username>`
7. `kata config-view` jika sudah berhasil unimpersonate, maka akan token untuk username yang dipilih akan terhapus