### PR TITLE
[HOTFIX] Cast timezone to a number to fix issue "should be number"

### DIFF
--- a/components/projects/project.ts
+++ b/components/projects/project.ts
@@ -45,6 +45,7 @@ export default class Project {
                 message: "Project description:",
             },
         ]);
+        inquiredOptions.timezone = Number(inquiredOptions.timezone)
         const options = { bot: true, cms: true, nlu: true, ...inquiredOptions };
 
         let nluOptions: any = {};


### PR DESCRIPTION
Related issue: https://gitlab.com/kata-ai/core/paltform-stabilisation/-/issues/58

How to test:
1. Create a project with the default parameter
2. Create a project with a custom timezone
3. They should behave identically apart from the timezone itself
